### PR TITLE
Changes on hover navigation

### DIFF
--- a/src/styles/lexicon-site/_sidebar-lexicon-site.scss
+++ b/src/styles/lexicon-site/_sidebar-lexicon-site.scss
@@ -90,8 +90,9 @@
 				font-size: 16px;
 				font-weight: 600;
 				line-height: 22px;
+                margin-left: $base-size * 1.5;
 				min-height: $base-size * 1.25;
-				padding-left: $base-size / 2 + $base-size * 1.5;
+				padding-left: $base-size / 2;
 			}
 
 			& ul > li > ul > li > a, .nav .nav > li > a {
@@ -111,15 +112,21 @@
 				}
 
 				&.lexicon-site-about:before {
-					@include square(25px, #6B6C7E);
+                    left: - $base-size * 1.357;
+
+                    @include square(22px, #6B6C7E);
 				}
 
 				&.lexicon-site-docs:before {
-					@include triangle(25px, #FFF);
+                    left: - $base-size * 1.4;
+
+                    @include triangle(25px, #FFF);
 				}
 
 				&.lexicon-site-news:before {
-					@include circle(25px, #FF6060);
+                    left: - $base-size * 1.4;
+
+                    @include circle(25px, #FF6060);
 				}
 			}
 		}


### PR DESCRIPTION
**1. Change the background size of the hover state on sidebar navigation to match the width of the list items.** 

Hover state level 1:

![image](https://user-images.githubusercontent.com/21121044/27173816-3731f0d4-51ba-11e7-8876-7437261f8642.png)

Hover state level 2:

![image](https://user-images.githubusercontent.com/21121044/27173837-44afcf7e-51ba-11e7-9c36-bbce93ddefd7.png)


**2. Adjust the size of the square icon to make it visually equivalent to the rest of the icons.**

Different icon size:

![image](https://user-images.githubusercontent.com/21121044/27173874-5af1eede-51ba-11e7-82e3-5c78a16b9e34.png)
